### PR TITLE
Print the coverage from JaCoCo

### DIFF
--- a/src/main/kotlin/com/ekino/oss/gradle/plugin/quality/QualityPlugin.kt
+++ b/src/main/kotlin/com/ekino/oss/gradle/plugin/quality/QualityPlugin.kt
@@ -4,6 +4,7 @@
 
 package com.ekino.oss.gradle.plugin.quality
 
+import com.ekino.oss.gradle.plugin.quality.task.PrintCoverageTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
@@ -14,7 +15,6 @@ import org.gradle.api.resources.TextResource
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.kotlin.dsl.*
 import org.gradle.testing.jacoco.plugins.JacocoPlugin
-import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.sonarqube.gradle.SonarQubeExtension
 import org.sonarqube.gradle.SonarQubePlugin
@@ -55,8 +55,13 @@ class QualityPlugin: Plugin<Project> {
           }
         }
 
+        val printCoverage by tasks.register<PrintCoverageTask>("printCoverage") {
+          htmlJacocoReport = "$buildDir/reports/jacoco/test/html/index.html"
+          mustRunAfter(jacocoTestReport)
+        }
+
         tasks.named("build") {
-          dependsOn(jacocoTestReport)
+          dependsOn(jacocoTestReport, printCoverage)
         }
 
         if (project.hasProperty("sonarCoverageExclusions")) {

--- a/src/main/kotlin/com/ekino/oss/gradle/plugin/quality/task/PrintCoverageTask.kt
+++ b/src/main/kotlin/com/ekino/oss/gradle/plugin/quality/task/PrintCoverageTask.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 ekino (https://www.ekino.com/)
+ */
+
+package com.ekino.oss.gradle.plugin.quality.task
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+open class PrintCoverageTask : DefaultTask() {
+    @Input
+    lateinit var htmlJacocoReport: String
+
+    @TaskAction
+    fun printCoverage() {
+        File(htmlJacocoReport).takeIf { it.exists() }?.apply {
+            ">Total<.+>(?<coverage>[0-9]+) ?%<".toRegex().find(readText())?.let {
+                println("COVERAGE: ${it.groups["coverage"]?.value}%")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/ekino/oss/gradle/plugin/quality/QualityPluginIT.kt
+++ b/src/test/kotlin/com/ekino/oss/gradle/plugin/quality/QualityPluginIT.kt
@@ -19,7 +19,7 @@ class QualityPluginIT {
   fun `Should check project quality with only test sourceSet`() {
     val result = runTask("project_with_test", "build", "sonar")
 
-    expectThat(result.tasks).hasSize(15)
+    expectThat(result.tasks).hasSize(16)
     expectThat(result.task(":checkstyleMain")).isNotNull()
     expectThat(result.task(":checkstyleTest")).isNotNull()
     expectThat(result.task(":jacocoTestReport")).isNotNull()
@@ -34,6 +34,8 @@ class QualityPluginIT {
     expectThat(result.task(":jacocoTestReport")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     expectThat(result.output.contains("Generating jacoco coverage report in HTML ...")).isTrue()
     expectThat(result.task(":sonarqube")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    expectThat(result.output.contains("COVERAGE: 25%")).isTrue()
+    expectThat(result.task(":printCoverage")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
     val jacocoTestExecFile = tempDir.resolve("build")
             .resolve("jacoco")
@@ -77,7 +79,7 @@ class QualityPluginIT {
   fun `Should check project quality with test and integrationTest sourceSets`() {
     val result = runTask("project_with_test_and_integration_test", "build", "sonar")
 
-    expectThat(result.tasks).hasSize(21)
+    expectThat(result.tasks).hasSize(22)
     expectThat(result.task(":checkstyleMain")).isNotNull()
     expectThat(result.task(":checkstyleTest")).isNotNull()
     expectThat(result.task(":checkstyleIntegrationTest")).isNotNull()
@@ -91,6 +93,8 @@ class QualityPluginIT {
     expectThat(result.task(":jacocoTestReport")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     expectThat(result.task(":sonarqube")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     expectThat(result.task(":aggregateJunitReports")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    expectThat(result.output.contains("COVERAGE: 0%")).isTrue()
+    expectThat(result.task(":printCoverage")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
     val jacocoTestExecFile = tempDir.resolve("build")
             .resolve("jacoco")

--- a/src/test/kotlin/com/ekino/oss/gradle/plugin/quality/QualityPluginTest.kt
+++ b/src/test/kotlin/com/ekino/oss/gradle/plugin/quality/QualityPluginTest.kt
@@ -20,8 +20,10 @@ class QualityPluginTest {
     expectThat(project.pluginManager.hasPlugin("java")).isTrue()
     expectThat(project.pluginManager.hasPlugin("checkstyle")).isTrue()
     expectThat(project.pluginManager.hasPlugin("org.sonarqube")).isTrue()
+
     expectThat(project.getTasksByName("checkstyleMain", false)).isNotEmpty()
     expectThat(project.getTasksByName("checkstyleTest", false)).isNotEmpty()
     expectThat(project.getTasksByName("sonarqube", false)).isNotEmpty()
+    expectThat(project.getTasksByName("printCoverage", false)).isNotEmpty()
   }
 }

--- a/src/test/resources/project_with_test/src/test/java/com/example/demo/DemoApplicationTest.java
+++ b/src/test/resources/project_with_test/src/test/java/com/example/demo/DemoApplicationTest.java
@@ -5,6 +5,6 @@ class DemoApplicationTest {
     @org.junit.jupiter.api.Test
     void should_test()
     {
-
+        DemoApplication.main(new String[]{});
     }
 }


### PR DESCRIPTION
It refers to #4 

It reads the coverage from the HTML report with a regex then prints it.