### PR TITLE
feat: add 7.3.3 to CompatibilityTest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
   id("se.bjurr.gitchangelog.git-changelog-gradle-plugin") version "1.71.5"
   id("org.sonarqube") version "3.3"
   id("com.gradle.plugin-publish") version "0.19.0"
+  id( "pl.droidsonroids.jacoco.testkit") version "1.0.9"
 }
 
 repositories {

--- a/src/main/kotlin/com/ekino/oss/gradle/plugin/quality/QualityPlugin.kt
+++ b/src/main/kotlin/com/ekino/oss/gradle/plugin/quality/QualityPlugin.kt
@@ -45,9 +45,9 @@ class QualityPlugin: Plugin<Project> {
             println("Generating jacoco coverage report in HTML ...")
           }
           reports {
-            xml.isEnabled = true
-            csv.isEnabled = false
-            html.isEnabled = true
+            xml.required.set(true)
+            csv.required.set(false)
+            html.required.set(true)
           }
           // To add ".exec" file from integrationTest task if exists
           tasks.findByName("integrationTest")?.let {

--- a/src/test/kotlin/com/ekino/oss/gradle/plugin/quality/GradleVersionsCompatibilityTest.kt
+++ b/src/test/kotlin/com/ekino/oss/gradle/plugin/quality/GradleVersionsCompatibilityTest.kt
@@ -14,7 +14,7 @@ class GradleVersionsCompatibilityTest {
     @TempDir
     lateinit var tempDir: File
 
-    @ValueSource(strings = ["6.3", "6.6.1", "6.8.3"])
+    @ValueSource(strings = ["6.3", "6.6.1", "6.8.3", "7.3.3"])
     @ParameterizedTest(name = "Gradle {0}")
     fun `Should work in gradle version`(gradleVersion: String) {
         val buildScript =
@@ -31,10 +31,17 @@ class GradleVersionsCompatibilityTest {
                 .withGradleVersion(gradleVersion)
                 .withPluginClasspath()
                 .withArguments("build", "--stacktrace")
+                .withJaCoCo()
                 .forwardOutput()
                 .build()
 
 
         expectThat(result.task(":build")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    private fun GradleRunner.withJaCoCo(): GradleRunner {
+        val s = javaClass.classLoader.getResourceAsStream("testkit-gradle.properties")?.bufferedReader()?.readText() ?: ""
+        File(projectDir, "gradle.properties").appendText(s)
+        return this
     }
 }

--- a/src/test/kotlin/com/ekino/oss/gradle/plugin/quality/QualityPluginIT.kt
+++ b/src/test/kotlin/com/ekino/oss/gradle/plugin/quality/QualityPluginIT.kt
@@ -168,6 +168,12 @@ class QualityPluginIT {
             .contains("""Unable to find: (.*) config/missing.xml""")
   }
 
+  private fun GradleRunner.withJaCoCo(): GradleRunner {
+    val s = javaClass.classLoader.getResourceAsStream("testkit-gradle.properties")?.bufferedReader()?.readText() ?: ""
+    File(projectDir, "gradle.properties").appendText(s)
+    return this
+  }
+
   private fun runTask(project: String, vararg task: String): BuildResult {
     File("src/test/resources/$project").copyRecursively(tempDir.toFile())
 
@@ -177,6 +183,7 @@ class QualityPluginIT {
             .withTestKitDir(tempDir.toFile())
             .withPluginClasspath()
             .forwardOutput()
+            .withJaCoCo()
             .build()
   }
 


### PR DESCRIPTION
* Fix remove deprecated "enabled" property by jacocoTestReport.
* Enable jacoco test for main plugin project, by using
support plugin "pl.droidsonroids.jacoco.testkit".

Hi There!

with this PR it would be possible to see coverage report of the main plugin 
itself under gradle-quality-plugin/build/reports/jacoco/test/html/index.html.

I hope this helps.
Kind regards
Thanh